### PR TITLE
Correct sudo usage

### DIFF
--- a/worksheet.md
+++ b/worksheet.md
@@ -428,7 +428,7 @@ if __name__ == '__main__':
 
 But feel free to make any modifications you see fit!
 
-Test that it works by navigating to the `tweeting-babbage` folder in the terminal with `cd` and running `python3 babbage.py`. Press `Ctrl + C` to exit.
+Test that it works by navigating to the `tweeting-babbage` folder in the terminal with `cd` and running `sudo python3 babbage.py`. Press `Ctrl + C` to exit.
 
 ## Automation
 
@@ -443,7 +443,7 @@ Lastly, we'll make the Python script run as soon as the Pi boots, as we won't ha
 1. Go down to the end of the file and add the following line just before the final line `exit 0`:
 
     ```
-    sudo python3 /home/pi/tweeting-babbage/babbage.py &
+    python3 /home/pi/tweeting-babbage/babbage.py &
     ```
 
     This runs the script when the Pi boots. The ampersand (&) is important as it makes the script run in a separate process, so that the Pi can continue to boot.


### PR DESCRIPTION
It *is* needed on the command-line, but it's not needed in `/etc/rc.local` (as it always gets run by `root` anyway).